### PR TITLE
Update docker-branch.yml

### DIFF
--- a/.github/workflows/docker-branch.yml
+++ b/.github/workflows/docker-branch.yml
@@ -6,6 +6,7 @@
 # The built images will be uploaded to our timescaledev account on dockerhub.
 # You can view them here: https://hub.docker.com/r/timescaledev/timescaledb/tags
 #
+#
 name: Docker Image for specific branch
 
 on:


### PR DESCRIPTION
The TS_VERSION environment variable is set to ${{ github.event.inputs.branch }}, which takes the value passed in the workflow dispatch event input branch. This allows us to specify the branch or tag to build when triggering the workflow.

The actions/checkout@v2 step is updated to use v2 version instead of v3.

The Build and push nightly Docker image for Postgres step is modified to use the make multi command with the appropriate arguments and tags.

An additional step, Push Docker image to DockerHub, is added to push the built Docker image to DockerHub with the specified tag.